### PR TITLE
chore: upgrade platform components

### DIFF
--- a/infra/controllers/base/altlantis/helm-release.yaml
+++ b/infra/controllers/base/altlantis/helm-release.yaml
@@ -17,5 +17,4 @@ spec:
         name: runatlantis
         namespace: flux-system
       interval: 12h
-      version: "5.17.*"
-
+      version: "6.5.*"

--- a/infra/controllers/base/cert-manager/helm-release.yaml
+++ b/infra/controllers/base/cert-manager/helm-release.yaml
@@ -17,7 +17,6 @@ spec:
         name: jetstack
         namespace: flux-system
       interval: 12h
-      version: "1.17.*"
+      version: "1.19.*"
   values:
     installCRDs: true
-

--- a/infra/controllers/base/cloudnative-pg/helm-release.yaml
+++ b/infra/controllers/base/cloudnative-pg/helm-release.yaml
@@ -17,7 +17,7 @@ spec:
         name: cnpg
         namespace: flux-system
       interval: 12h
-      version: "0.26.*"
+      version: "0.28.*"
   # https://github.com/cloudnative-pg/charts
   values:
     crds:
@@ -32,4 +32,3 @@ spec:
     monitoring:
       # -- Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.
       podMonitorEnabled: false
-

--- a/infra/controllers/base/istio/kustomization.yaml
+++ b/infra/controllers/base/istio/kustomization.yaml
@@ -19,6 +19,6 @@ patches:
         interval: 72h
         chart:
           spec:
-            version: "1.27.*"
+            version: "1.30.*"
     target:
       kind: HelmRelease

--- a/infra/controllers/base/kiali/helm-release.yaml
+++ b/infra/controllers/base/kiali/helm-release.yaml
@@ -18,7 +18,7 @@ spec:
         namespace: flux-system
       # istio <=> kiali Version Compatibility
       # https://kiali.io/docs/installation/installation-guide/prerequisites/
-      version: "2.10.*"
+      version: "2.27.*"
       interval: 12h
   values:
     cr:

--- a/infra/controllers/base/kong-gateway/helm-release.yaml
+++ b/infra/controllers/base/kong-gateway/helm-release.yaml
@@ -20,7 +20,7 @@ spec:
         name: kong
         namespace: flux-system
       # https://github.com/Kong/charts/blob/main/charts/ingress/Chart.yaml
-      version: "0.19.*"
+      version: "0.24.*"
       interval: 12h
   values:
     gatewayDiscovery:

--- a/infra/controllers/base/loki/helm-release.yaml
+++ b/infra/controllers/base/loki/helm-release.yaml
@@ -12,9 +12,9 @@ spec:
       chart: loki
       sourceRef:
         kind: HelmRepository
-        name: grafana
+        name: grafana-community
         namespace: flux-system
-      version: "6.*"
+      version: "17.1.*"
       interval: 12h
   # https://github.com/grafana/loki/tree/main/production/helm/loki
   values:
@@ -31,8 +31,8 @@ spec:
         - name: ca-certs
           mountPath: /data/ca-certs
           readOnly: true
-    deploymentMode: SingleBinary
-    singleBinary:
+    deploymentMode: Monolithic
+    monolithic:
       replicas: 1
       extraVolumes: *extraVolumes
       extraVolumeMounts: *extraVolumeMounts

--- a/infra/controllers/base/loki/helm-repo.yaml
+++ b/infra/controllers/base/loki/helm-repo.yaml
@@ -2,8 +2,9 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: grafana
+  name: grafana-community
   namespace: flux-system
 spec:
   interval: 12h
-  url: https://grafana.github.io/helm-charts 
+  type: oci
+  url: oci://ghcr.io/grafana-community/helm-charts

--- a/infra/controllers/base/longhorn/helm-release.yaml
+++ b/infra/controllers/base/longhorn/helm-release.yaml
@@ -12,11 +12,11 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: longhorn-repo
-      version: 1.8.*
+      version: 1.12.*
   interval: 30m0s
-  # https://github.com/longhorn/charts/blob/v1.6.x/charts/longhorn/values.yaml
+  # https://github.com/longhorn/charts/blob/v1.12.x/charts/longhorn/values.yaml
   values:
-    # https://longhorn.io/docs/1.6.2/best-practices/#volume-performance-optimization
+    # https://longhorn.io/docs/1.12.0/best-practices/#volume-performance-optimization
     persistence:
       defaultClass: true
       # -- Filesystem type of the default Longhorn StorageClass.
@@ -24,13 +24,13 @@ spec:
       # 2 replicas to achieve data availability with better disk space usage or less impact to system performance
       defaultClassReplicaCount: 2
       # -- Data locality of the default Longhorn StorageClass. (Options: "disabled", "best-effort", "strict-local")
-      # https://longhorn.io/docs/1.6.2/high-availability/data-locality/
+      # https://longhorn.io/docs/1.12.0/high-availability/data-locality/
       defaultDataLocality: best-effort # to gain better io performance
       # -- Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete")
       reclaimPolicy: Delete
       migratable: false # disable by default, security concern
     defaultSettings:
-      # https://longhorn.io/docs/1.6.2/high-availability/auto-balance-replicas/
+      # https://longhorn.io/docs/1.12.0/high-availability/auto-balance-replicas/
       replicaAutoBalance: "best-effort"
       defaultReplicaCount: 2
       defaultDataLocality: best-effort # to gain better io performance

--- a/infra/controllers/base/otel-collector/helm-release.yaml
+++ b/infra/controllers/base/otel-collector/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: open-telemetry
         namespace: flux-system
-      version: "0.126.*"
+      version: "0.158.*"
       interval: 12h
   # https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
   values:
@@ -104,7 +104,7 @@ spec:
             X-Scope-OrgID: "fake"
 
       processors:
-        k8sattributes:
+        k8s_attributes:
           passthrough: false
           filter:
             node_from_env_var: K8S_NODE_NAME
@@ -222,7 +222,7 @@ spec:
         pipelines:
           logs:
             receivers: [otlp, filelog]
-            processors: [k8sattributes, transform] # Order is crucial
+            processors: [k8s_attributes, transform] # Order is crucial
             exporters: [otlphttp]
           traces: null
           metrics: null # we use vmagent for metrics collecting.

--- a/infra/controllers/base/victoria-metrics/helm-release.yaml
+++ b/infra/controllers/base/victoria-metrics/helm-release.yaml
@@ -18,7 +18,7 @@ spec:
         kind: HelmRepository
         name: victoria-metrics
         namespace: flux-system
-      version: "0.50.*"
+      version: "0.81.*"
       interval: 12h
   # https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack
   values:
@@ -31,6 +31,13 @@ spec:
     # https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-operator/values.yaml
     victoria-metrics-operator:
       enabled: true
+      crds:
+        plain: true
+        cleanup:
+          enabled: false
+        upgrade:
+          enabled: true
+          forceConflicts: true
       serviceMonitor:
         enabled: true
         # -- Creates `VMServiceScrape` if `true` and `ServiceMonitor` otherwise.

--- a/infra/controllers/overlays/k3s-test-1/helmrelease-loki.yaml
+++ b/infra/controllers/overlays/k3s-test-1/helmrelease-loki.yaml
@@ -28,4 +28,5 @@ spec:
         type: s3
         bucketNames: # for object storage
           chunks: k3s-test-1-loki-chunks
-
+          ruler: k3s-test-1-loki-ruler
+          admin: k3s-test-1-loki-admin

--- a/infra/controllers/overlays/k3s-test-1/helmrelease-otel-collector.yaml
+++ b/infra/controllers/overlays/k3s-test-1/helmrelease-otel-collector.yaml
@@ -16,4 +16,4 @@ spec:
       service:
         pipelines:
           logs:
-            processors: [k8sattributes, resource, transform] # Order is crucial
+            processors: [k8s_attributes, resource, transform] # Order is crucial

--- a/infra/pre-controllers/base/cilium/helm-release.yaml
+++ b/infra/pre-controllers/base/cilium/helm-release.yaml
@@ -17,8 +17,8 @@ spec:
         name: cilium
         namespace: flux-system
       interval: 12h
-      version: "1.17.*"
-  # https://github.com/cilium/cilium/tree/v1.17.4/install/kubernetes/cilium
+      version: "1.19.*"
+  # https://github.com/cilium/cilium/tree/v1.19.4/install/kubernetes/cilium
   values:
     # ======================== Work with Istio ========================
     # https://docs.cilium.io/en/latest/network/servicemesh/istio/
@@ -34,6 +34,4 @@ spec:
       enabled: true
     # -- Enables masquerading of IPv6 traffic leaving the node from endpoints.
     enableIPv6Masquerade: true
-
-
 


### PR DESCRIPTION
Phase 1 conservative update: upgrade validated Helm-managed platform components and required values/schema adjustments while leaving static CRD/operator bundles for a later phase. Chart versions are pinned at major.minor.* so patch releases can roll forward automatically.

Updated version constraints:

- Atlantis chart 5.17.* -> 6.5.*

- cert-manager chart 1.17.* -> 1.19.*

- CloudNativePG chart 0.26.* -> 0.28.*

- Istio charts 1.27.* -> 1.30.*

- Kiali operator chart 2.10.* -> 2.27.*

- Kong ingress chart 0.19.* -> 0.24.*

- Loki chart 6.* -> grafana-community/loki 17.1.*

- Longhorn chart 1.8.* -> 1.12.*

- OpenTelemetry Collector chart 0.126.* -> 0.158.*

- VictoriaMetrics k8s stack chart 0.50.* -> 0.81.*

- Cilium chart 1.17.* -> 1.19.*

Compatibility notes:

- Renames the OTel k8s attributes processor to k8s_attributes for the newer collector chart.

- Enables VictoriaMetrics operator CRD upgrade handling with forceConflicts for chart 0.81.x.

- Migrates Loki to the Grafana community OCI chart and adds required ruler/admin bucket names without changing encrypted SOPS values.

Deferred to later phases:

- Flux bootstrap manifests remain at v2.5.1.

- Gateway API static bundle remains v1.3.0.

- KubeVirt, CDI, and cluster-network-addons static manifests remain unchanged.

- kube-vip and application image tags are not updated in this phase.

Verification:

- ./scripts/validate.sh